### PR TITLE
Add new `-AnsiEscColor` option to Write-Host function.

### DIFF
--- a/PSMultiLog.psm1
+++ b/PSMultiLog.psm1
@@ -1296,16 +1296,20 @@ Function Write-HostLog {
         [psobject]$Entry
     )
 
-    Process {
-    $SGRESC="$([char]27)"
-    $CLEAR="$SGRESC[0m"
+    Begin {
+        $SGRESC ="$([char]27)"
+        $CLEAR  ="$SGRESC[0m"
+        $CYAN   ="$SGRESC[96m"
+        $YELLOW ="$SGRESC[33m"
+        $RED    ="$SGRESC[31m"
+    }
 
+    Process {
         Write-Host -Object "[$($Entry.Timestamp.ToString("u"))] - " -NoNewline
 
         switch ($Entry.EntryType) {
             "Information" {
                 if ($Script:Settings["Host"].AnsiEscColor) {
-                    $CYAN="$SGRESC[96m"
                     Write-Host -Object ($CYAN + $Script:r.Info + $CLEAR) -NoNewline
                 } else {
                     Write-Host -Object $Script:r.Info -ForegroundColor Cyan -NoNewline
@@ -1314,7 +1318,6 @@ Function Write-HostLog {
 
             "Warning" {
                 if ($Script:Settings["Host"].AnsiEscColor) {
-                    $YELLOW="$SGRESC[33m"
                     Write-Host -Object ($YELLOW + $Script:r.Warn + $CLEAR) -NoNewline
                 } else {
                     Write-Host -Object $Script:r.Warn -ForegroundColor Yellow -NoNewline
@@ -1323,7 +1326,6 @@ Function Write-HostLog {
 
             "Error" {
                 if ($Script:Settings["Host"].AnsiEscColor) {
-                    $RED="$SGRESC[31m"
                     Write-Host -Object ($RED + $Script:r.Errr + $CLEAR) -NoNewline
                 } else {
                     Write-Host -Object $Script:r.Errr -ForegroundColor Red -NoNewline

--- a/PSMultiLog.psm1
+++ b/PSMultiLog.psm1
@@ -43,6 +43,7 @@ $Script:Settings = @{
     Host = New-Object -TypeName psobject -Property @{
         Enabled = $false
         LogLevel = 0
+        AnsiEscColor = $false
     }
 
     PassThru = New-Object -TypeName psobject -Property @{
@@ -620,6 +621,9 @@ Function Start-HostLog {
     Specifies the minimum log entry severity to write to the host. The default
     value is "Error".
 
+    .PARAMETER AnsiEscColor
+    Enables ANSI escape color.
+
     .OUTPUTS
     None.
 
@@ -634,12 +638,17 @@ Function Start-HostLog {
     Param (
         [Parameter()]
         [ValidateSet("Information", "Warning", "Error")]
-        [string]$LogLevel = "Error"
+        [string]$LogLevel = "Error",
+
+        [Parameter()]
+        [ValidateSet($true, $false)]
+        [switch]$AnsiEscColor = $false
     )
 
     Process {
         $Script:Settings["Host"].Enabled = $true
         $Script:Settings["Host"].LogLevel = Get-LogLevel -EntryType $LogLevel
+        $Script:Settings["Host"].AnsiEscColor = $AnsiEscColor
     }
 }
 
@@ -1288,24 +1297,42 @@ Function Write-HostLog {
     )
 
     Process {
+    $SGRESC="$([char]27)"
+    $CLEAR="$SGRESC[0m"
+
         Write-Host -Object "[$($Entry.Timestamp.ToString("u"))] - " -NoNewline
 
         switch ($Entry.EntryType) {
             "Information" {
-                Write-Host -Object $Script:r.Info -ForegroundColor Cyan -NoNewline
+                if ($Script:Settings["Host"].AnsiEscColor) {
+                    $CYAN="$SGRESC[96m"
+                    Write-Host -Object ($CYAN + $Script:r.Info + $CLEAR) -NoNewline
+                } else {
+                    Write-Host -Object $Script:r.Info -ForegroundColor Cyan -NoNewline
+                }
             }
 
             "Warning" {
-                Write-Host -Object $Script:r.Warn -ForegroundColor Yellow -NoNewline
+                if ($Script:Settings["Host"].AnsiEscColor) {
+                    $YELLOW="$SGRESC[33m"
+                    Write-Host -Object ($YELLOW + $Script:r.Warn + $CLEAR) -NoNewline
+                } else {
+                    Write-Host -Object $Script:r.Warn -ForegroundColor Yellow -NoNewline
+                }
             }
 
             "Error" {
-                Write-Host -Object $Script:r.Errr -ForegroundColor Red -NoNewline
+                if ($Script:Settings["Host"].AnsiEscColor) {
+                    $RED="$SGRESC[31m"
+                    Write-Host -Object ($RED + $Script:r.Errr + $CLEAR) -NoNewline
+                } else {
+                    Write-Host -Object $Script:r.Errr -ForegroundColor Red -NoNewline
+                }
             }
         }
 
         $Message = $Entry.Message
-        
+
         if ($Entry.Exception) {
             $Message += " - $($Script:r.Exception): $($Entry.Exception.Message)"
         }

--- a/Tests/PSMultiLog.tests.ps1
+++ b/Tests/PSMultiLog.tests.ps1
@@ -308,6 +308,7 @@ Describe Start-HostLog {
         It "Sets the log level" {
             Start-HostLog
             $Script:Settings["Host"].LogLevel | Should Be 0
+            $Script:Settings["Host"].AnsiEscColor | Should Be $false
 
             Start-HostLog -LogLevel "Error"
             $Script:Settings["Host"].LogLevel | Should Be 0
@@ -317,6 +318,9 @@ Describe Start-HostLog {
 
             Start-HostLog -LogLevel "Information"
             $Script:Settings["Host"].LogLevel | Should Be 2
+            
+            Start-HostLog -AnsiEscColor
+            $Script:Settings["Host"].AnsiEscColor | Should Be $true          
         }
     }
 }


### PR DESCRIPTION
I changed it because the LogLevel string ("INFO", "WARN", "ERRR") shows without color in GitLab CI/CD terminal. Then I found a document (add-color-codes-to-script-output) mentioned about it, so I made this change. The pasted a screenshot for original result and changed result.

Your code is clear and good readability, I am not sure does my change fit for this project. Let me know if any suggestion.

![image](https://user-images.githubusercontent.com/3453968/107138174-d7de4b00-694d-11eb-82a6-b423a8b385cb.png)
